### PR TITLE
style(.gitattributes): Ensure consistent line-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# This file ensures line endings are properly handled across Windows/Linux
+# See https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings
+
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto


### PR DESCRIPTION
Linux and Windows handles line endings in files differently. Adding "* text=auto" here ensures consistent behavior for all devs, regardless of their Git settings and environment.

See https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings