### PR TITLE
fix(create azure resource): Resource naming convention bugs

### DIFF
--- a/src/Sepes.Infrastructure/Util/AzureResourceNameUtil.cs
+++ b/src/Sepes.Infrastructure/Util/AzureResourceNameUtil.cs
@@ -62,13 +62,13 @@ namespace Sepes.Infrastructure.Util
             var studyNameNormalized = MakeStringAlphanumeric(studyName);
             var sanboxNameNormalized = MakeStringAlphanumeric(sandboxName);
 
-            return AzureResourceNameConstructor("stdiag", studyNameNormalized, sanboxNameNormalized, maxLength: 24, avoidDash: true);
+            return AzureResourceNameConstructor("stdiag", studyNameNormalized, sanboxNameNormalized, maxLength: 24, addUniqueEnding:true, avoidDash: true);
         }
 
         public static string VirtualMachine(string sandboxName) => StripWhitespace($"vm-{sandboxName}");
 
 
-        static string AzureResourceNameConstructor(string prefix, string studyName, string sandboxName, int maxLength = 64, bool addUniqueEnding = false, bool avoidDash = false)
+        public static string AzureResourceNameConstructor(string prefix, string studyName, string sandboxName, int maxLength = 64, bool addUniqueEnding = false, bool avoidDash = false)
         {
             var shortUniquePart = addUniqueEnding ? (avoidDash ? "" : "-") + Guid.NewGuid().ToString().ToLower().Substring(0, 3) : "";
             var availableSpaceForStudyAndSanboxName = maxLength - prefix.Length - shortUniquePart.Length - (avoidDash ? 0 : 1);
@@ -101,7 +101,8 @@ namespace Sepes.Infrastructure.Util
                 if (charachtersLeft < 0)
                 {
                     var mustRemoveEach = Math.Abs(charachtersLeft) / 2;
-                    normalizedStudyName = normalizedStudyName.Substring(0, normalizedStudyName.Length - mustRemoveEach);
+                    var even = charachtersLeft % 2 == 0;
+                    normalizedStudyName = normalizedStudyName.Substring(0, normalizedStudyName.Length - mustRemoveEach - (even ? 0 : 1));
                     normalizedSanboxName = normalizedSanboxName.Substring(0, normalizedSanboxName.Length - mustRemoveEach);
                 }
             }

--- a/src/Sepes.Infrastructure/Util/AzureResourceNameUtil.cs
+++ b/src/Sepes.Infrastructure/Util/AzureResourceNameUtil.cs
@@ -49,18 +49,18 @@ namespace Sepes.Infrastructure.Util
         public static string StorageAccount(string sandboxName)
         {
             var shortGuid = Guid.NewGuid().ToString().ToLower().Substring(0, 3);
-            sandboxName = MakeStringAlphanumeric(sandboxName);
+            sandboxName = MakeStringAlphanumericAndRemoveWhitespace(sandboxName);
             if (sandboxName.Length > 18)
             {
                 return $"st{sandboxName.ToLower().Substring(0, 18)}{shortGuid}";
             }
             return $"st{sandboxName.ToLower()}{shortGuid}";
-        }
+        }      
 
         public static string DiagnosticsStorageAccount(string studyName, string sandboxName)
         {
-            var studyNameNormalized = MakeStringAlphanumeric(studyName);
-            var sanboxNameNormalized = MakeStringAlphanumeric(sandboxName);
+            var studyNameNormalized = MakeStringAlphanumericAndRemoveWhitespace(studyName);
+            var sanboxNameNormalized = MakeStringAlphanumericAndRemoveWhitespace(sandboxName);
 
             return AzureResourceNameConstructor("stdiag", studyNameNormalized, sanboxNameNormalized, maxLength: 24, addUniqueEnding:true, avoidDash: true);
         }
@@ -116,14 +116,14 @@ namespace Sepes.Infrastructure.Util
         }
 
 
-        static string MakeStringAlphanumeric(string str) => new string((from c in str
-                                                                        where char.IsLetterOrDigit(c) && !char.IsWhiteSpace(c)
-                                                                        select c
+        public static string MakeStringAlphanumericAndRemoveWhitespace(string str) => new string((from c in str
+                                                                        where char.IsLetterOrDigit(c) && !char.IsWhiteSpace(c) && c != 'æ' && c != 'ø' && c != 'å'
+                                                                                                  select c
                                                                        ).ToArray());
 
-        static string StripWhitespace(string str) => new string((from c in str
-                                                                 where !char.IsWhiteSpace(c)
-                                                                 select c
+        public static string StripWhitespace(string str) => new string((from c in str
+                                                                 where !char.IsWhiteSpace(c) && c != 'æ' && c != 'ø' && c != 'å'
+                                                                        select c
                                                                 ).ToArray());
 
 

--- a/src/Sepes.Tests/Util/AzureResourceNameUtilTest.cs
+++ b/src/Sepes.Tests/Util/AzureResourceNameUtilTest.cs
@@ -32,18 +32,18 @@ namespace Sepes.Tests.Util
         [Fact]
         public void DiagStorageAccountName_ShouldNotExceed24Characters()
         {
-            var resourceName = AzureResourceNameUtil.DiagnosticsStorageAccount("Bestest Study Ever", "The third test we are going to to");
+            var resourceName = AzureResourceNameUtil.DiagnosticsStorageAccount("Bestest Study Ever", "Strezztest1");
             Assert.InRange(resourceName.Length, 4, 24);
             Assert.Contains("stdiag", resourceName);
-            Assert.Contains("best", resourceName);
-            Assert.Contains("thethi", resourceName);
+            Assert.Contains("bestes", resourceName);
+            Assert.Contains("strezzte", resourceName);
 
 
             var resourceName2 = AzureResourceNameUtil.DiagnosticsStorageAccount("Bestest Study Ever", "The third test we are going to too");
             Assert.InRange(resourceName2.Length, 4, 24);
             Assert.Contains("stdiag", resourceName2);
-            Assert.Contains("best", resourceName2);
-            Assert.Contains("thethi", resourceName2);
+            Assert.Contains("bestest", resourceName2);
+            Assert.Contains("thethird", resourceName2);
 
         }
 

--- a/src/Sepes.Tests/Util/AzureResourceNameUtilTest.cs
+++ b/src/Sepes.Tests/Util/AzureResourceNameUtilTest.cs
@@ -47,5 +47,27 @@ namespace Sepes.Tests.Util
 
         }
 
-    }
+        [Fact]
+        public void ResourceGroupName_ShouldFilterAwayNorwegianSpecialLetters()
+        {
+
+
+
+            var resourceName = AzureResourceNameUtil.ResourceGroup("A revolutional Støddy with a long name", "Bæste sandbåx ju kæn tink");
+            Assert.InRange(resourceName.Length, 4, 64);            
+            Assert.Contains("rg-study-arevolutionalstddywithalongname-bstesandbxjukntink-", resourceName);
+
+        }
+
+        [Fact]
+        public void DiagStorageAccountName_ShouldFilterAwayNorwegianSpecialLetters()
+        {
+            var resourceName = AzureResourceNameUtil.DiagnosticsStorageAccount("Støddy", "Bæste sandbåx");
+            Assert.InRange(resourceName.Length, 4, 24);
+     
+            Assert.Contains("stdiagstddybstesandbx", resourceName);
+   
+        }
+
+        }
 }


### PR DESCRIPTION
…torageaccount

It sometimes produced name above 24 characters. Also did not create unique names for similar
study/sandbox names.

It also did not remove æ,ø,å. These letters cause trouble when used for resources

Closes #317
Closes #318