### PR TITLE
Fix/improve reschedule sandbox creation

### DIFF
--- a/src/Sepes.Infrastructure/Dto/Sandbox/ProvisioningQueueChildDto.cs
+++ b/src/Sepes.Infrastructure/Dto/Sandbox/ProvisioningQueueChildDto.cs
@@ -1,9 +1,7 @@
 ﻿namespace Sepes.Infrastructure.Dto
 {
     public class ProvisioningQueueChildDto
-    {
-        public int SandboxResourceId { get; set; }
-
+    { 
         public int SandboxResourceOperationId { get; set; }   
         
     }

--- a/src/Sepes.Infrastructure/Service/Interface/ISandboxResourceService.cs
+++ b/src/Sepes.Infrastructure/Service/Interface/ISandboxResourceService.cs
@@ -18,10 +18,10 @@ namespace Sepes.Infrastructure.Service
         Task<SandboxResourceDto> Create(SandboxWithCloudResourcesDto dto, string type, string resourceName);
 
 
-        Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, string type, string resourceId, string resourceName);
-        Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, Microsoft.Azure.Management.Network.Models.Resource resourceGroup);
-        Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, IResource resource);
-        Task<SandboxResourceDto> AddResourceGroup(int sandboxId, string resourceGroupId, string resourceGroupName, string type);
+        //Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, string type, string resourceId, string resourceName);
+        //Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, Microsoft.Azure.Management.Network.Models.Resource resourceGroup);
+        //Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, IResource resource);
+        //Task<SandboxResourceDto> AddResourceGroup(int sandboxId, string resourceGroupId, string resourceGroupName, string type);
         Task<SandboxResourceDto> GetByIdAsync(int id);
         Task<SandboxResourceDto> MarkAsDeletedByIdAsync(int id);
         Task<SandboxResourceDto> UpdateResourceGroup(int resourceId, SandboxResourceDto updated);

--- a/src/Sepes.Infrastructure/Service/Interface/ISandboxService.cs
+++ b/src/Sepes.Infrastructure/Service/Interface/ISandboxService.cs
@@ -14,7 +14,7 @@ namespace Sepes.Infrastructure.Service.Interface
         Task<SandboxDto> DeleteAsync(int studyId, int sandboxId);
 
         Task<List<SandboxResourceLightDto>> GetSandboxResources(int studyId, int sandboxId);
-        Task ReScheduleSandboxCreation(int studyId, int sandboxId);
+        Task ReScheduleSandboxCreation(int studyId);
 
         //Task<IEnumerable<SandboxTemplateDto>> GetTemplatesAsync();
     }

--- a/src/Sepes.Infrastructure/Service/SandboxResourceService.cs
+++ b/src/Sepes.Infrastructure/Service/SandboxResourceService.cs
@@ -117,33 +117,33 @@ namespace Sepes.Infrastructure.Service
             return newResource;
         }
 
-        public async Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, string type, string resourceId, string resourceName)
-        {
-            var sandboxFromDb = await GetSandboxOrThrowAsync(sandboxId);
+        //public async Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, string type, string resourceId, string resourceName)
+        //{
+        //    var sandboxFromDb = await GetSandboxOrThrowAsync(sandboxId);
 
-            var newResource = new SandboxResource()
-            {
-                ResourceGroupId = resourceGroupId,
-                ResourceGroupName = resourceGroupName,
-                ResourceType = type,
-                ResourceName = resourceName,
-                Status = ""
-            };
+        //    var newResource = new SandboxResource()
+        //    {
+        //        ResourceGroupId = resourceGroupId,
+        //        ResourceGroupName = resourceGroupName,
+        //        ResourceType = type,
+        //        ResourceName = resourceName,
+        //        Status = ""
+        //    };
 
-            sandboxFromDb.Resources.Add(newResource);
-            await _db.SaveChangesAsync();
+        //    sandboxFromDb.Resources.Add(newResource);
+        //    await _db.SaveChangesAsync();
 
-            return await GetByIdAsync(newResource.Id);
-        }
+        //    return await GetByIdAsync(newResource.Id);
+        //}
 
-        public async Task<SandboxResourceDto> AddResourceGroup(int sandboxId, string resourceGroupId, string resourceGroupName, string type) =>
-            await Add(sandboxId, resourceGroupId, resourceGroupName, type, resourceGroupId, resourceGroupName);
+        //public async Task<SandboxResourceDto> AddResourceGroup(int sandboxId, string resourceGroupId, string resourceGroupName, string type) =>
+        //    await Add(sandboxId, resourceGroupId, resourceGroupName, type, resourceGroupId, resourceGroupName);
 
-        public async Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, Microsoft.Azure.Management.Network.Models.Resource resource) =>
-            await Add(sandboxId, resourceGroupId, resourceGroupName, resource.Type, resource.Id, resource.Name);
+        //public async Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, Microsoft.Azure.Management.Network.Models.Resource resource) =>
+        //    await Add(sandboxId, resourceGroupId, resourceGroupName, resource.Type, resource.Id, resource.Name);
 
-        public async Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, IResource resource) =>
-            await Add(sandboxId, resourceGroupId, resourceGroupName, resource.Type, resource.Id, resource.Name);
+        //public async Task<SandboxResourceDto> Add(int sandboxId, string resourceGroupId, string resourceGroupName, IResource resource) =>
+        //    await Add(sandboxId, resourceGroupId, resourceGroupName, resource.Type, resource.Id, resource.Name);
 
         //ResourceGroup
         //Nsg

--- a/src/Sepes.Infrastructure/Service/SandboxService.cs
+++ b/src/Sepes.Infrastructure/Service/SandboxService.cs
@@ -346,7 +346,7 @@ namespace Sepes.Infrastructure.Service
                 {
                     throw new NullReferenceException($"ReScheduleSandboxCreation. StudyId: {sandboxFromDb.StudyId}, SandboxId: {sandboxId}, ResourceId: {curResource.Id}: Could not locate ANY database entry for ResourceGroupOperation");
                 }
-                else if (relevantOperation.Status == CloudResourceOperationState.NOT_STARTED  || relevantOperation.Status == CloudResourceOperationState.FAILED)
+                else if (relevantOperation.Status == CloudResourceOperationState.NOT_STARTED  || relevantOperation.Status == CloudResourceOperationState.FAILED || String.IsNullOrWhiteSpace(relevantOperation.Status))
                 {
                     queueParentItem.Children.Add(new ProvisioningQueueChildDto() { SandboxResourceOperationId = relevantOperation.Id });
                 }

--- a/src/Sepes.Infrastructure/Service/SandboxService.cs
+++ b/src/Sepes.Infrastructure/Service/SandboxService.cs
@@ -111,8 +111,6 @@ namespace Sepes.Infrastructure.Service
             studyFromDb.Sandboxes.Add(sandbox);
             await _db.SaveChangesAsync();
 
-
-
             // Get Dtos for arguments to sandboxWorkerService
             var studyDto = await _studyService.GetStudyByIdAsync(studyId);
             var sandboxDto = await GetSandboxDtoAsync(sandbox.Id);
@@ -301,7 +299,7 @@ namespace Sepes.Infrastructure.Service
             return _mapper.Map<SandboxDto>(sandboxFromDb);
         }
 
-        public async Task ReScheduleSandboxCreation(int studyId, int sandboxId)
+        public async Task ReScheduleSandboxCreation(int sandboxId)
         {
             var sandboxFromDb = await GetSandboxOrThrowAsync(sandboxId, UserOperations.StudyReadOwnRestricted);
 
@@ -315,18 +313,18 @@ namespace Sepes.Infrastructure.Service
 
             if (resourceGroupResource == null)
             {
-                throw new NullReferenceException($"ReScheduleSandboxCreation. StudyId: {studyId}, SandboxId: {sandboxId}: Could not locate database entry for ResourceGroup");
+                throw new NullReferenceException($"ReScheduleSandboxCreation. StudyId: {sandboxFromDb.StudyId}, SandboxId: {sandboxId}: Could not locate database entry for ResourceGroup");
             }
 
             var resourceGroupResourceOperation = resourceGroupResource.Operations.OrderByDescending(o => o.Created).FirstOrDefault();
 
             if (resourceGroupResourceOperation == null)
             {
-                throw new NullReferenceException($"ReScheduleSandboxCreation. StudyId: {studyId}, SandboxId: {sandboxId}: Could not locate ANY database entry for ResourceGroupOperation");
+                throw new NullReferenceException($"ReScheduleSandboxCreation. StudyId: {sandboxFromDb.StudyId}, SandboxId: {sandboxId}: Could not locate ANY database entry for ResourceGroupOperation");
             }
             else if (resourceGroupResourceOperation.OperationType != CloudResourceOperationType.CREATE && resourceGroupResourceOperation.Status == CloudResourceOperationState.DONE_SUCCESSFUL)
             {
-                throw new Exception($"ReScheduleSandboxCreation. StudyId: {studyId}, SandboxId: {sandboxId}: Could not locate RELEVANT database entry for ResourceGroupOperation");
+                throw new Exception($"ReScheduleSandboxCreation. StudyId: {sandboxFromDb.StudyId}, SandboxId: {sandboxId}: Could not locate RELEVANT database entry for ResourceGroupOperation");
             }
 
             //Rest of resources must have failed, cannot handle partial creation yet
@@ -346,30 +344,31 @@ namespace Sepes.Infrastructure.Service
 
                 if (relevantOperation == null)
                 {
-                    throw new NullReferenceException($"ReScheduleSandboxCreation. StudyId: {studyId}, SandboxId: {sandboxId}, ResourceId: {curResource.Id}: Could not locate ANY database entry for ResourceGroupOperation");
+                    throw new NullReferenceException($"ReScheduleSandboxCreation. StudyId: {sandboxFromDb.StudyId}, SandboxId: {sandboxId}, ResourceId: {curResource.Id}: Could not locate ANY database entry for ResourceGroupOperation");
                 }
-                else if (relevantOperation.Status == CloudResourceOperationState.NOT_STARTED || relevantOperation.Status == CloudResourceOperationState.FAILED)
+                else if (relevantOperation.Status == CloudResourceOperationState.NOT_STARTED  || relevantOperation.Status == CloudResourceOperationState.FAILED)
                 {
                     queueParentItem.Children.Add(new ProvisioningQueueChildDto() { SandboxResourceId = curResource.Id, SandboxResourceOperationId = relevantOperation.Id });
                 }
+                //else if(relevantOperation.Status == CloudResourceOperationState.IN_PROGRESS || relevantOperation.Status == CloudResourceOperationState.DONE_SUCCESSFUL)
+                //{
+                //    //Resource might be under creation or finished
+                //}
                 else
                 {
-                    throw new Exception($"ReScheduleSandboxCreation. StudyId: {studyId}, SandboxId: {sandboxId}, ResourceId: {curResource.Id}: Could not locate RELEVANT database entry for ResourceGroupOperation");
+                    throw new Exception($"ReScheduleSandboxCreation. StudyId: {sandboxFromDb.StudyId}, SandboxId: {sandboxId}, ResourceId: {curResource.Id}: Could not locate RELEVANT database entry for ResourceGroupOperation");
                 }
             }
 
             if (queueParentItem.Children.Count == 0)
             {
-                throw new Exception($"ReScheduleSandboxCreation. StudyId: {studyId}, SandboxId: {sandboxId}: Could not re-shedule creation. No relevant resource items found");
+                throw new Exception($"ReScheduleSandboxCreation. StudyId: {sandboxFromDb.StudyId}, SandboxId: {sandboxId}: Could not re-shedule creation. No relevant resource items found");
             }
             else
             {
                 await _provisioningQueueService.SendMessageAsync(queueParentItem);
-
             }
         }
-
-
 
         //public Task<IEnumerable<SandboxTemplateDto>> GetTemplatesAsync()
         //{

--- a/src/Sepes.Infrastructure/Service/SandboxService.cs
+++ b/src/Sepes.Infrastructure/Service/SandboxService.cs
@@ -208,7 +208,7 @@ namespace Sepes.Infrastructure.Service
         async Task<SandboxResourceDto> CreateResource(SandboxWithCloudResourcesDto dto, ProvisioningQueueParentDto queueParentItem, string resourceType, string resourceName = AzureResourceNameUtil.AZURE_RESOURCE_INITIAL_NAME)
         {
             var resourceEntry = await _sandboxResourceService.Create(dto, resourceType, resourceName);
-            queueParentItem.Children.Add(new ProvisioningQueueChildDto() { SandboxResourceId = resourceEntry.Id.Value, SandboxResourceOperationId = resourceEntry.Operations.FirstOrDefault().Id.Value });
+            queueParentItem.Children.Add(new ProvisioningQueueChildDto() { SandboxResourceOperationId = resourceEntry.Operations.FirstOrDefault().Id.Value });
 
             return resourceEntry;
         }
@@ -286,7 +286,7 @@ namespace Sepes.Infrastructure.Service
                 var queueParentItem = new ProvisioningQueueParentDto();
                 queueParentItem.SandboxId = sandboxId;
                 queueParentItem.Description = $"Delete resources for Sandbox: {sandboxId}";
-                queueParentItem.Children.Add(new ProvisioningQueueChildDto() { SandboxResourceId = sandboxResourceGroup.Id, SandboxResourceOperationId = deleteOperation.Id });
+                queueParentItem.Children.Add(new ProvisioningQueueChildDto() { SandboxResourceOperationId = deleteOperation.Id });
                 await _provisioningQueueService.SendMessageAsync(queueParentItem);
             }
             else
@@ -348,7 +348,7 @@ namespace Sepes.Infrastructure.Service
                 }
                 else if (relevantOperation.Status == CloudResourceOperationState.NOT_STARTED  || relevantOperation.Status == CloudResourceOperationState.FAILED)
                 {
-                    queueParentItem.Children.Add(new ProvisioningQueueChildDto() { SandboxResourceId = curResource.Id, SandboxResourceOperationId = relevantOperation.Id });
+                    queueParentItem.Children.Add(new ProvisioningQueueChildDto() { SandboxResourceOperationId = relevantOperation.Id });
                 }
                 //else if(relevantOperation.Status == CloudResourceOperationState.IN_PROGRESS || relevantOperation.Status == CloudResourceOperationState.DONE_SUCCESSFUL)
                 //{

--- a/src/Sepes.RestApi/Controllers/StudyController_Sandbox.cs
+++ b/src/Sepes.RestApi/Controllers/StudyController_Sandbox.cs
@@ -67,9 +67,9 @@ namespace Sepes.RestApi.Controller
 
         [HttpPut("{studyId}/sandboxes/{sandboxId}/rescheduleCreation")]
         [Authorize(Roles = AppRoles.Admin)]    
-        public async Task<IActionResult> GetTemplatesLookupAsync(int studyId, int sandboxId)
+        public async Task<IActionResult> ReScheduleCreation(int studyId, int sandboxId)
         {
-            await _sandboxService.ReScheduleSandboxCreation(studyId, sandboxId);
+            await _sandboxService.ReScheduleSandboxCreation(sandboxId);
             return new NoContentResult();
         }
 

--- a/src/Sepes.Tests/Services/Azure/ResourceProvisioningQueueServiceTests.cs
+++ b/src/Sepes.Tests/Services/Azure/ResourceProvisioningQueueServiceTests.cs
@@ -19,8 +19,7 @@ namespace Sepes.Tests.Services.Azure
         {          
             Children = new System.Collections.Generic.List<ProvisioningQueueChildDto>() {
 
-                new ProvisioningQueueChildDto(){
-                  SandboxResourceId = 1,
+                new ProvisioningQueueChildDto(){            
                   SandboxResourceOperationId = 2                
                 }
             }
@@ -63,7 +62,6 @@ namespace Sepes.Tests.Services.Azure
 
             var messageChild = msgsAfter.Children.SingleOrDefault();
             Assert.NotNull(messageChild);
-            Assert.Equal(1, messageChild.SandboxResourceId);
             Assert.Equal(2, messageChild.SandboxResourceOperationId);       
      
 


### PR DESCRIPTION
Have started work on a routine for re-scheduling resource operations that are deleted from the queue. 
It's still a fragile routine. It can only pick off if ONLY resource group has been created 