### PR TITLE
fix(vm): vm extended info endpoint, renamed MemoryInDb to MemoryGB

### DIFF
--- a/src/Sepes.Infrastructure/Dto/VirtualMachine/VmSizeDto.cs
+++ b/src/Sepes.Infrastructure/Dto/VirtualMachine/VmSizeDto.cs
@@ -12,7 +12,7 @@ namespace Sepes.Infrastructure.Dto.VirtualMachine
 
         public int ResourceDiskSizeInMB { get; set; }
 
-        public int MemoryInMB { get; set; }
+        public int MemoryGB { get; set; }
 
         public int MaxDataDiskCount { get; set; }
 


### PR DESCRIPTION
mapping got broken when started caching vm sizes in db