### PR TITLE
refactor: removed sandbox endpoints that were simplified 

### DIFF
--- a/src/Sepes.RestApi/Controllers/SandboxController.cs
+++ b/src/Sepes.RestApi/Controllers/SandboxController.cs
@@ -36,35 +36,14 @@ namespace Sepes.RestApi.Controller
         {
             var sandboxes = await _sandboxService.GetAllForStudy(studyId);
             return new JsonResult(sandboxes);
-        }
-
-        [HttpGet("studies/{studyId}/sandboxes/{sandboxId}")]
-        public async Task<IActionResult> GetSandbox(int studyId, int sandboxId)
-        {
-            var sandboxes = await _sandboxService.GetSandboxDetailsAsync(sandboxId);
-            return new JsonResult(sandboxes);
-        }
+        }     
 
         [HttpGet("sandboxes/{sandboxId}")]
         public async Task<IActionResult> GetSandboxAsync(int sandboxId)
         {
             var sandboxes = await _sandboxService.GetSandboxDetailsAsync(sandboxId);
             return new JsonResult(sandboxes);
-        }
-
-        [HttpGet("studies/{studyId}/sandboxes/{sandboxId}/resources")]
-        public async Task<IActionResult> GetSandboxResources(int studyId, int sandboxId)
-        {
-            var sandboxes = await _sandboxService.GetSandboxResources(sandboxId);
-            return new JsonResult(sandboxes);
-        }
-
-        [HttpDelete("studies/{studyId}/sandboxes/{sandboxId}")]
-        public async Task<IActionResult> RemoveSandboxOld(int studyId, int sandboxId)
-        {
-           await _sandboxService.DeleteAsync(sandboxId);
-            return new NoContentResult();
-        }
+        }  
 
         [HttpDelete("sandboxes/{sandboxId}")]
         public async Task<IActionResult> RemoveSandboxAsync(int sandboxId)

--- a/src/Sepes.RestApi/Controllers/SandboxResourceController.cs
+++ b/src/Sepes.RestApi/Controllers/SandboxResourceController.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
-using Sepes.Infrastructure.Constants;
 using Sepes.Infrastructure.Service.Interface;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
The new endpoints does not have the /studies/studyId part.

GET studies/{studyId}/sandboxes/{sandboxId},
GET studies/{studyId}/sandboxes/{sandboxId}/resources,
DELETE studies/{studyId}/sandboxes/{sandboxId}

BREAKING CHANGE: three endpoints described above are replaced by endpoints not requiring the
studies/studyId part