### PR TITLE
fix(vm): vm not getting stuck in updating if previous attempt failed

### DIFF
--- a/src/Sepes.Infrastructure/Service/CloudResourceOperation/CloudResourceOperationCreateService.cs
+++ b/src/Sepes.Infrastructure/Service/CloudResourceOperation/CloudResourceOperationCreateService.cs
@@ -42,11 +42,11 @@ namespace Sepes.Infrastructure.Service
 
             if (dependsOn == 0)
             {
-                var mustDependOn = await CheckIfOperationsToWaitFor(sandboxResourceFromDb, currentUser);  
+                var mustWaitFor = await CheckAnyIfOperationsToWaitFor(sandboxResourceFromDb, currentUser);  
                 
-                if(mustDependOn != null)
+                if(mustWaitFor != null)
                 {
-                    dependsOn = mustDependOn.Id;
+                    dependsOn = mustWaitFor.Id;
                 }
             }
 
@@ -67,7 +67,7 @@ namespace Sepes.Infrastructure.Service
             return await GetOperationDtoInternal(newOperation.Id);
         }
 
-        async Task<CloudResourceOperation> CheckIfOperationsToWaitFor(CloudResource resource, UserDto currentUser)
+        async Task<CloudResourceOperation> CheckAnyIfOperationsToWaitFor(CloudResource resource, UserDto currentUser)
         {
 
             bool mostRecentOperation = true;

--- a/src/Sepes.Infrastructure/Util/Provisioning/CreateAndUpdateUtil.cs
+++ b/src/Sepes.Infrastructure/Util/Provisioning/CreateAndUpdateUtil.cs
@@ -72,7 +72,7 @@ namespace Sepes.Infrastructure.Util.Provisioning
                 }
                 else
                 {
-                    throw new ProvisioningException($"Resource provisioning (Create/update) failed.", innerException: ex);
+                    throw new ProvisioningException($"Resource provisioning (Create/update) failed.", CloudResourceOperationState.FAILED, postponeQueueItemFor: 10, innerException: ex);
                 }
             }
         }

--- a/src/Sepes.Infrastructure/Util/Provisioning/OperationCheckUtils.cs
+++ b/src/Sepes.Infrastructure/Util/Provisioning/OperationCheckUtils.cs
@@ -34,7 +34,7 @@ namespace Sepes.Infrastructure.Util.Provisioning
         {
             if (operation.Status == CloudResourceOperationState.IN_PROGRESS)
             {
-                if (operation.Updated.AddMinutes(2) >= DateTime.UtcNow) //If changed less than two minutes ago
+                if (operation.Updated.AddMinutes(1) >= DateTime.UtcNow) //If changed less than two minutes ago
                 {
                     throw new ProvisioningException($"Possibly allready in progress", proceedWithOtherOperations: false, deleteFromQueue: false, postponeQueueItemFor: 60, logAsWarning: true);
                 }


### PR DESCRIPTION
typically happends when a rule update fails, no new operation is started because it's waiting the
previous one.
closes #433