### PR TITLE
fix(vm): now rolling back, if creation fails in the create response

### DIFF
--- a/src/Sepes.Infrastructure/Service/CloudResource/CloudResourceDeleteService.cs
+++ b/src/Sepes.Infrastructure/Service/CloudResource/CloudResourceDeleteService.cs
@@ -128,5 +128,22 @@ namespace Sepes.Infrastructure.Service
 
             return resource;
         }
+
+        public async Task HardDeletedAsync(int resourceId)
+        {
+            var resourceFromDb = await GetInternalAsync(resourceId);
+
+            if(resourceFromDb != null)
+            {
+                foreach(var curOperation in resourceFromDb.Operations)
+                {
+                    _db.CloudResourceOperations.Remove(curOperation);
+                }
+
+                _db.CloudResources.Remove(resourceFromDb);
+
+                await _db.SaveChangesAsync();
+            }
+        }
     }
 }

--- a/src/Sepes.Infrastructure/Service/CloudResource/Interface/ICloudResourceDeleteService.cs
+++ b/src/Sepes.Infrastructure/Service/CloudResource/Interface/ICloudResourceDeleteService.cs
@@ -7,6 +7,8 @@ namespace Sepes.Infrastructure.Service.Interface
     {         
         Task<CloudResourceDto> MarkAsDeletedAsync(int resourceId);
 
+        Task HardDeletedAsync(int resourceId);
+
         Task<CloudResourceOperationDto> MarkAsDeletedWithDeleteOperationAsync(int resourceId);
     }
 }


### PR DESCRIPTION
before, they would appear to be stuck in "creating" state, allthough the create operation was never
queued