### PR TITLE
fix(logging): dont log all provisioning exceptions as exceptions to A…

### DIFF
--- a/src/Sepes.Infrastructure/Exceptions/ProvisioningException.cs
+++ b/src/Sepes.Infrastructure/Exceptions/ProvisioningException.cs
@@ -4,25 +4,7 @@ using System.Text;
 namespace Sepes.Infrastructure.Exceptions
 {
     public class ProvisioningException : Exception
-    {
-        public ProvisioningException(string message,
-            string newOperationStatus = null,
-            bool proceedWithOtherOperations = false,
-            bool deleteFromQueue = false,
-            int? postponeQueueItemFor = default,
-            bool storeQueueInfoOnOperation = false,
-             bool logAsWarning = false,
-            Exception innerException = null)
-            : base(message, innerException)
-        {
-            NewOperationStatus = newOperationStatus;
-            ProceedWithOtherOperations = proceedWithOtherOperations;
-            DeleteFromQueue = deleteFromQueue;
-            PostponeQueueItemFor = postponeQueueItemFor;
-            StoreQueueInfoOnOperation = storeQueueInfoOnOperation;
-            LogAsWarning = logAsWarning;
-        }
-
+    {  
         public bool DeleteFromQueue { get; set; }
 
         public int? PostponeQueueItemFor { get; set; }
@@ -34,6 +16,28 @@ namespace Sepes.Infrastructure.Exceptions
         public bool StoreQueueInfoOnOperation { get; set; }
 
         public bool LogAsWarning { get; set; }
+
+        public bool IncludeExceptionInWarningLog { get; set; }
+
+        public ProvisioningException(string message,
+          string newOperationStatus = null,
+          bool proceedWithOtherOperations = false,
+          bool deleteFromQueue = false,
+          int? postponeQueueItemFor = default,
+          bool storeQueueInfoOnOperation = false,
+          bool logAsWarning = false,
+          bool includeExceptionInWarningLog = true,
+          Exception innerException = null)
+          : base(message, innerException)
+        {
+            NewOperationStatus = newOperationStatus;
+            ProceedWithOtherOperations = proceedWithOtherOperations;
+            DeleteFromQueue = deleteFromQueue;
+            PostponeQueueItemFor = postponeQueueItemFor;
+            StoreQueueInfoOnOperation = storeQueueInfoOnOperation;
+            LogAsWarning = logAsWarning;
+            IncludeExceptionInWarningLog = includeExceptionInWarningLog;
+        }
 
         public string GetMessageSummary()
         {

--- a/src/Sepes.Infrastructure/Service/ResourceProvisioningService.cs
+++ b/src/Sepes.Infrastructure/Service/ResourceProvisioningService.cs
@@ -153,7 +153,14 @@ namespace Sepes.Infrastructure.Service
                     {
                         if (ex.LogAsWarning)
                         {
-                            _logger.LogWarning(ex, ProvisioningLogUtil.Operation(currentOperation, "Operation aborted"));
+                            if (ex.IncludeExceptionInWarningLog)
+                            {
+                                _logger.LogWarning(ex, ProvisioningLogUtil.Operation(currentOperation, "Operation aborted"));
+                            }
+                            else
+                            {
+                                _logger.LogWarning(ProvisioningLogUtil.Operation(currentOperation, $"Operation aborted: {ex.Message}"));
+                            }                          
                         }
                         else
                         {

--- a/src/Sepes.Infrastructure/Util/Provisioning/OperationCheckUtils.cs
+++ b/src/Sepes.Infrastructure/Util/Provisioning/OperationCheckUtils.cs
@@ -14,11 +14,11 @@ namespace Sepes.Infrastructure.Util.Provisioning
         {
             if (operation.Status == CloudResourceOperationState.ABORTED)
             {
-                throw new ProvisioningException($"Operation is aborted", proceedWithOtherOperations: false, deleteFromQueue: true, logAsWarning: true);
+                throw new ProvisioningException($"Operation is aborted", proceedWithOtherOperations: false, deleteFromQueue: true, logAsWarning: true, includeExceptionInWarningLog: false);
             }
             else if (operation.TryCount >= operation.MaxTryCount)
             {
-                throw new ProvisioningException($"Max retry count exceeded: {operation.TryCount}", newOperationStatus: CloudResourceOperationState.FAILED, proceedWithOtherOperations: false, deleteFromQueue: true, logAsWarning: true);
+                throw new ProvisioningException($"Max retry count exceeded: {operation.TryCount}", newOperationStatus: CloudResourceOperationState.FAILED, proceedWithOtherOperations: false, deleteFromQueue: true, logAsWarning: true, includeExceptionInWarningLog: false);
             }
         }
 
@@ -26,7 +26,7 @@ namespace Sepes.Infrastructure.Util.Provisioning
         {
             if (operation.Resource.Deleted.HasValue && operation.OperationType != CloudResourceOperationType.DELETE)
             {
-                throw new ProvisioningException($"Resource is marked for deletion in database", newOperationStatus: CloudResourceOperationState.ABORTED, proceedWithOtherOperations: false, deleteFromQueue: true, logAsWarning: true);
+                throw new ProvisioningException($"Resource is marked for deletion in database", newOperationStatus: CloudResourceOperationState.ABORTED, proceedWithOtherOperations: false, deleteFromQueue: true, logAsWarning: true, includeExceptionInWarningLog: false);
             }
         }
 
@@ -36,7 +36,7 @@ namespace Sepes.Infrastructure.Util.Provisioning
             {
                 if (operation.Updated.AddMinutes(1) >= DateTime.UtcNow) //If changed less than two minutes ago
                 {
-                    throw new ProvisioningException($"Possibly allready in progress", proceedWithOtherOperations: false, deleteFromQueue: false, postponeQueueItemFor: 60, logAsWarning: true);
+                    throw new ProvisioningException($"Possibly allready in progress", proceedWithOtherOperations: false, deleteFromQueue: false, postponeQueueItemFor: 60, logAsWarning: true, includeExceptionInWarningLog: false);
                 }
             }
         }
@@ -51,7 +51,7 @@ namespace Sepes.Infrastructure.Util.Provisioning
 
                     bool storeQueueInformationOnOperation = queueParentItem.Children.Count == 1;
 
-                    throw new ProvisioningException($"Dependant operation {operation.DependsOnOperationId.Value} is not finished. Invisibility increased by {increaseBy}", proceedWithOtherOperations: false, deleteFromQueue: false, postponeQueueItemFor: increaseBy, storeQueueInfoOnOperation: storeQueueInformationOnOperation, logAsWarning: true);                               
+                    throw new ProvisioningException($"Dependant operation {operation.DependsOnOperationId.Value} is not finished. Invisibility increased by {increaseBy}", proceedWithOtherOperations: false, deleteFromQueue: false, postponeQueueItemFor: increaseBy, storeQueueInfoOnOperation: storeQueueInformationOnOperation, logAsWarning: true, includeExceptionInWarningLog: false);                               
 
                 }
             }


### PR DESCRIPTION
…pp Insights

they are used to control the flow of the app, and does not have to be logged as exception.