### PR TITLE
fix: better handle TaskCancelledException and dont log as error

### DIFF
--- a/src/Sepes.RestApi/Middleware/ErrorHandlingMiddleware.cs
+++ b/src/Sepes.RestApi/Middleware/ErrorHandlingMiddleware.cs
@@ -56,7 +56,16 @@ namespace Sepes.RestApi.Middelware
                    requestId, ex, HttpStatusCode.BadRequest);
 
                 await HandleExceptionAsync(context, result.Content, result.StatusCode);
-            }          
+            }
+            catch (TaskCanceledException ex)
+            {
+                log.LogInformation($"Task was cancelled: {method} {path}, requestId: {requestId}");
+
+                var result = JsonExceptionResultFactory.CreateExceptionMessageResult(
+                   requestId, ex, HttpStatusCode.Continue);
+
+                await HandleExceptionAsync(context, result.Content, result.StatusCode);
+            }
             catch (Exception ex)
             {
                 LogHelper.LogError(log, ex, path, method);


### PR DESCRIPTION
it was cluttering app insights with ex messages

closes #483