### PR TITLE
fix(dataset): assign custom role for dataset resource group

### DIFF
--- a/src/Sepes.Azure/Service/AzureRoleAssignmentService.cs
+++ b/src/Sepes.Azure/Service/AzureRoleAssignmentService.cs
@@ -17,6 +17,7 @@ namespace Sepes.Azure.Service
 {
     public class AzureRoleAssignmentService : AzureApiServiceBase, IAzureRoleAssignmentService 
     {
+        const string API_VERSION_ARGUMENT = "api-version=2018-07-01";
         readonly string _subscriptionId;
 
         public AzureRoleAssignmentService(IConfiguration config, ILogger<AzureRoleAssignmentService> logger, ITokenAcquisition tokenAcquisition, HttpClient httpClient)
@@ -50,7 +51,7 @@ namespace Sepes.Azure.Service
                     roleAssignmentId = Guid.NewGuid().ToString();
                 }
 
-                var addRoleUrl = $"https://management.azure.com{resourceId}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentId}?api-version=2015-07-01";
+                var addRoleUrl = $"https://management.azure.com{resourceId}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentId}?{API_VERSION_ARGUMENT}";
 
                 var body = new AzureRoleAssignmentRequestDto(roleDefinitionId, principalId);
                 var bodyJson = new StringContent(JsonSerializerUtil.Serialize(body), Encoding.UTF8, "application/json");
@@ -84,17 +85,34 @@ namespace Sepes.Azure.Service
 
         string CreateLinkForExistingRoleAssignment(string roleAssignmentId)
         {
-            return $"https://management.azure.com{roleAssignmentId}?api-version=2015-07-01";
+            return $"https://management.azure.com{roleAssignmentId}?{API_VERSION_ARGUMENT}";
         }
 
         public async Task<List<AzureRoleAssignment>> GetResourceGroupRoleAssignments(string resourceGroupId, string resourceGroupName, CancellationToken cancellation = default)
         {
-            var url = $"https://management.azure.com/subscriptions/{_subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Authorization/roleAssignments?api-version=2015-07-01&$filter=atScope()";
-            var assignmentsFromAzure = await PerformRequest<RoleAssignmentResponse>(url, HttpMethod.Get, needsAuth: true, cancellationToken: cancellation);
- 
+            var url = $"https://management.azure.com/subscriptions/{_subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Authorization/roleAssignments";
+            var assignmentsFromAzure = await GetRoleAssignments(url, cancellation);
+
             var filteredRoleAssignments = assignmentsFromAzure.value.Where(ra => ra.properties.scope.Contains($"/resourceGroups/{resourceGroupId}") || ra.properties.scope.Contains($"/resourceGroups/{resourceGroupName}")).ToList();
 
             return filteredRoleAssignments;
         }
+
+        public async Task<List<AzureRoleAssignment>> GetStorageAccountRoleAssignments(string resourceGroupId, string resourceGroupName, string storageAccountId, string storageAccountName, CancellationToken cancellation = default)
+        {
+            var url = $"https://management.azure.com/subscriptions/{_subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{storageAccountName}/providers/Microsoft.Authorization/roleAssignments";
+            var assignmentsFromAzure = await GetRoleAssignments(url, cancellation);        
+            var filteredRoleAssignments = assignmentsFromAzure.value.Where(ra => ra.properties.scope.Contains($"/storageAccounts/{storageAccountId}") || ra.properties.scope.Contains($"/storageAccounts/{storageAccountName}")).ToList();
+
+            return filteredRoleAssignments;
+        }
+
+        async Task<RoleAssignmentResponse> GetRoleAssignments(string url, CancellationToken cancellation = default)
+        {          
+            var completeUrl = $"{url}?{API_VERSION_ARGUMENT}&$filter=atScope()";
+            var assignmentsFromAzure = await PerformRequest<RoleAssignmentResponse>(completeUrl, HttpMethod.Get, needsAuth: true, cancellationToken: cancellation);
+
+            return assignmentsFromAzure;
+        }      
     }
 }

--- a/src/Sepes.Azure/Service/Interface/IAzureRoleAssignmentService.cs
+++ b/src/Sepes.Azure/Service/Interface/IAzureRoleAssignmentService.cs
@@ -13,5 +13,6 @@ namespace Sepes.Azure.Service.Interface
         
         Task<AzureRoleAssignment> DeleteRoleAssignment(string roleAssignmentId, CancellationToken cancellationToken = default);
         Task<List<AzureRoleAssignment>> GetResourceGroupRoleAssignments(string resourceGroupId, string resourceGroupName, CancellationToken cancellation = default);
+        Task<List<AzureRoleAssignment>> GetStorageAccountRoleAssignments(string resourceGroupId, string resourceGroupName, string storageAccountId, string storageAccountName, CancellationToken cancellation = default);
     }
 }

--- a/src/Sepes.Common/Constants/Auth/AzureRoleIds.cs
+++ b/src/Sepes.Common/Constants/Auth/AzureRoleIds.cs
@@ -4,7 +4,7 @@
     {
         public const string OWNER = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635";
         public const string READ = "acdd72a7-3385-48ef-bd42-f606fba81ae7";
-        public const string CONTRIBUTOR = "b24988ac-6180-42a0-ab88-20f7382dd24c";
+        public const string CONTRIBUTOR = "b24988ac-6180-42a0-ab88-20f7382dd24c";      
 
 
         public static string CreateRoleDefinitionUrl(string resourceId, string roleId)

--- a/src/Sepes.Common/Constants/ConfigConstants.cs
+++ b/src/Sepes.Common/Constants/ConfigConstants.cs
@@ -53,5 +53,7 @@
         public const string WBS_SEARCH_API_URL = "WbsSearchBaseUrl";
         public const string WBS_SEARCH_API_SCOPE = "WbsSearchScope";
         public const string WBS_SEARCH_APIM_SUBSCRIPTION = "WbsSearchApimSubscriptionKey";
+
+        public const string DATASET_STORAGEACCOUNT_ROLE_ASSIGNMENT_ID = "DatasetStorageAccountRoleAssignmentId";
     }
 }

--- a/src/Sepes.Functions/Startup.cs
+++ b/src/Sepes.Functions/Startup.cs
@@ -104,6 +104,7 @@ namespace Sepes.Functions
             builder.Services.AddTransient<ICloudResourceMonitoringService, CloudResourceMonitoringService>();
             builder.Services.AddTransient<IResourceProvisioningService, ResourceProvisioningService>();
             builder.Services.AddTransient<IRoleProvisioningService, RoleProvisioningService>();
+            builder.Services.AddTransient<IParticipantRoleTranslatorService, ParticipantRoleTranslatorService>();
             builder.Services.AddTransient<IProvisioningQueueService, ProvisioningQueueService>();
             builder.Services.AddTransient<IProvisioningQueueService, ProvisioningQueueService>();
             builder.Services.AddTransient<ICorsRuleProvisioningService, CorsRuleProvisioningService>();

--- a/src/Sepes.Functions/appsettings.dev.txt
+++ b/src/Sepes.Functions/appsettings.dev.txt
@@ -12,4 +12,5 @@
 "ResourceProvisioningQueueConnectionString=@Microsoft.KeyVault(SecretUri=https://#{KeyvaultName}#.vault.azure.net/secrets/ResourceProvisioningQueueConnectionString)"
 "SepesRWConnectionString=@Microsoft.KeyVault(SecretUri=https://#{KeyvaultName}#.vault.azure.net/secrets/sepesrw-connectionstring)"
 "SubscriptionId=@Microsoft.KeyVault(SecretUri=https://#{KeyvaultName}#.vault.azure.net/secrets/SubscriptionId)"
+"DatasetStorageAccountRoleAssignmentId=@Microsoft.KeyVault(SecretUri=https://#{KeyvaultName}#.vault.azure.net/secrets/DatasetStorageAccountRoleAssignmentId)"
 "FUNCTIONS_WORKER_RUNTIME=dotnet"

--- a/src/Sepes.Functions/appsettings.prod.txt
+++ b/src/Sepes.Functions/appsettings.prod.txt
@@ -12,4 +12,5 @@
 "ResourceProvisioningQueueConnectionString=@Microsoft.KeyVault(SecretUri=https://#{KeyvaultName}#.vault.azure.net/secrets/ResourceProvisioningQueueConnectionString)"
 "SepesRWConnectionString=@Microsoft.KeyVault(SecretUri=https://#{KeyvaultName}#.vault.azure.net/secrets/sepesrwconnectionstring)"
 "SubscriptionId=@Microsoft.KeyVault(SecretUri=https://#{KeyvaultName}#.vault.azure.net/secrets/SubscriptionId)"
+"DatasetStorageAccountRoleAssignmentId=@Microsoft.KeyVault(SecretUri=https://#{KeyvaultName}#.vault.azure.net/secrets/DatasetStorageAccountRoleAssignmentId)"
 "FUNCTIONS_WORKER_RUNTIME=dotnet"

--- a/src/Sepes.Infrastructure/Service/DataModelService/CloudResource/Interface/ICloudResourceReadService.cs
+++ b/src/Sepes.Infrastructure/Service/DataModelService/CloudResource/Interface/ICloudResourceReadService.cs
@@ -24,5 +24,6 @@ namespace Sepes.Infrastructure.Service.DataModelService.Interface
 
         Task<bool> ResourceIsDeleted(int resourceId);
         Task<List<CloudResource>> GetSandboxResourcesForDeletion(int sandboxId);
+        Task<List<int>> GetDatasetStorageAccountIdsForStudy(int studyId);
     }
 }

--- a/src/Sepes.Infrastructure/Service/Dataset/DatasetCloudResourceService.cs
+++ b/src/Sepes.Infrastructure/Service/Dataset/DatasetCloudResourceService.cs
@@ -208,8 +208,8 @@ namespace Sepes.Infrastructure.Service
 
                 var resourceEntry = await _cloudResourceCreateService.CreateStudySpecificDatasetEntryAsync(dataset.Id, resourceGroup.Id, resourceGroup.Region, resourceGroup.ResourceGroupName, storageAccountName, tagsForStorageAccount);
 
-                ProvisioningQueueUtil.CreateChildAndAdd(queueParent, resourceEntry);
-
+                ProvisioningQueueUtil.CreateChildAndAdd(queueParent, resourceEntry); 
+                
                 var serverPublicIp = await _publicIpService.GetIp();
 
                 DatasetFirewallUtils.EnsureDatasetHasFirewallRules(_logger, currentUser, dataset, clientIp, serverPublicIp);

--- a/src/Sepes.Infrastructure/Service/StudyParticipant/StudyParticipantBaseService.cs
+++ b/src/Sepes.Infrastructure/Service/StudyParticipant/StudyParticipantBaseService.cs
@@ -89,6 +89,7 @@ namespace Sepes.Infrastructure.Service
         protected async Task CreateRoleUpdateOperationsAsync(int studyId)
         {
             var resourcesToUpdate = await _cloudResourceReadService.GetDatasetResourceGroupIdsForStudy(studyId);
+            //resourcesToUpdate.AddRange(await _cloudResourceReadService.GetDatasetStorageAccountIdsForStudy(studyId)); //As of now, permissions are granted on the resource group for the storage accounts.
             resourcesToUpdate.AddRange(await _cloudResourceReadService.GetSandboxResourceGroupIdsForStudy(studyId));
 
             foreach (var currentResourceId in resourcesToUpdate)

--- a/src/Sepes.Infrastructure/Service/StudyParticipant/StudyParticipantCreateService.cs
+++ b/src/Sepes.Infrastructure/Service/StudyParticipant/StudyParticipantCreateService.cs
@@ -1,7 +1,6 @@
 ﻿using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Sepes.Azure.Dto;
 using Sepes.Azure.Service.Interface;
 using Sepes.Common.Constants;
 using Sepes.Common.Dto;
@@ -45,8 +44,6 @@ namespace Sepes.Infrastructure.Service
             try
             {
                 ValidateRoleNameThrowIfInvalid(role);
-
-
 
                 StudyParticipantDto newlyAddedParticipant = null;
 

--- a/src/Sepes.Provisioning/Service/Interface/IParticipantRoleTranslatorService.cs
+++ b/src/Sepes.Provisioning/Service/Interface/IParticipantRoleTranslatorService.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using Sepes.Common.Dto;
+using Sepes.Infrastructure.Model;
+
+namespace Sepes.Provisioning.Service.Interface
+{
+    public interface IParticipantRoleTranslatorService
+    {
+        List<CloudResourceDesiredRoleAssignmentDto> CreateDesiredRolesForStudyDatasetResourceGroup(List<StudyParticipant> participants);
+        List<CloudResourceDesiredRoleAssignmentDto> CreateDesiredRolesForSandboxResourceGroup(List<StudyParticipant> participants);
+    }
+}

--- a/src/Sepes.RestApi.IntegrationTests/Setup/CustomWebApplicationFactory.cs
+++ b/src/Sepes.RestApi.IntegrationTests/Setup/CustomWebApplicationFactory.cs
@@ -107,7 +107,8 @@ namespace Sepes.RestApi.IntegrationTests.Setup
                                [ConfigConstants.IS_INTEGRATION_TEST] = "true",
                                ["AllowCorsDomains"] = "http://localhost:80",
                                ["CostAllocationTypeTagName"] = "INTTEST-CostAllocationType",
-                               ["CostAllocationCodeTagName"] = "INTTEST-CostAllocationCode"
+                               ["CostAllocationCodeTagName"] = "INTTEST-CostAllocationCode",
+                               ["DatasetStorageAccountRoleAssignmentId"] = "9145904e-a892-473a-b559-8d87b9858407" 
                            });
             });
         }

--- a/src/Sepes.RestApi/Startup.cs
+++ b/src/Sepes.RestApi/Startup.cs
@@ -163,9 +163,7 @@ namespace Sepes.RestApi
                 services.AddHttpClient<IAzureRoleAssignmentService, AzureRoleAssignmentService>();
                 services.AddHttpClient<IAzureVirtualMachineOperatingSystemService, AzureVirtualMachineOperatingSystemService>();
                 services.AddHttpClient<IWbsApiService, WbsApiService>();
-              
                 
-
                 //Azure Services
                 services.AddTransient<IAzureResourceGroupService, AzureResourceGroupService>();
                 services.AddTransient<IAzureNetworkSecurityGroupService, AzureNetworkSecurityGroupService>();

--- a/src/Sepes.RestApi/Startup.cs
+++ b/src/Sepes.RestApi/Startup.cs
@@ -242,7 +242,7 @@ namespace Sepes.RestApi
             services.AddTransient<ICloudResourceMonitoringService, CloudResourceMonitoringService>();
             services.AddTransient<IResourceProvisioningService, ResourceProvisioningService>();
             services.AddTransient<IRoleProvisioningService, RoleProvisioningService>();
-            services.AddTransient<IProvisioningQueueService, ProvisioningQueueService>();
+            services.AddTransient<IParticipantRoleTranslatorService, ParticipantRoleTranslatorService>();
             services.AddTransient<IProvisioningQueueService, ProvisioningQueueService>();
             services.AddTransient<ICorsRuleProvisioningService, CorsRuleProvisioningService>();
             services.AddTransient<ICreateAndUpdateService, CreateAndUpdateService>();
@@ -251,15 +251,13 @@ namespace Sepes.RestApi
             services.AddTransient<IOperationCheckService, OperationCheckService>();
             services.AddTransient<IOperationCompletedService, OperationCompletedService>();
 
-            //Ext System Facade Services
-            services.AddTransient<IRoleProvisioningService, RoleProvisioningService>();
+            //Ext System Facade Services           
             services.AddTransient<IDatasetFileService, DatasetFileService>();
             services.AddTransient<IStudyLogoCreateService, StudyLogoCreateService>();
             services.AddTransient<IStudyLogoReadService, StudyLogoReadService>();
             services.AddTransient<IStudyLogoDeleteService, StudyLogoDeleteService>();
-            services.AddTransient<IStudySpecificDatasetService, StudySpecificDatasetService>();
-            services.AddTransient<IProvisioningQueueService, ProvisioningQueueService>();
-            services.AddTransient<IResourceProvisioningService, ResourceProvisioningService>();
+            services.AddTransient<IStudySpecificDatasetService, StudySpecificDatasetService>();          
+         
             services.AddTransient<ISandboxResourceCreateService, SandboxResourceCreateService>();
             services.AddTransient<ISandboxResourceRetryService, SandboxResourceRetryService>();
             services.AddTransient<ISandboxResourceDeleteService, SandboxResourceDeleteService>();


### PR DESCRIPTION
Previously, the reader role was assigned for owners and sponsor rep, on the resource group containing the datasets. This role did not grant permission to create/read/delete blobs. A custom role has been created instead. This fix ensures that role assignment is set instead. The worker must have the id set in config, key is
Closes #692