### PR TITLE
fix(wbsvalidation): better cache duplication handling

### DIFF
--- a/src/Sepes.Common/Exceptions/CustomUserMessageException.cs
+++ b/src/Sepes.Common/Exceptions/CustomUserMessageException.cs
@@ -15,7 +15,7 @@ namespace Sepes.Common.Exceptions
             StatusCode = httpStatusCode;
         }
         
-        public CustomUserMessageException(string message, System.Exception inner, string userFriendlyMessage = null, HttpStatusCode? httpStatusCode = default) : base(message, inner)  {
+        public CustomUserMessageException(string message, Exception inner, string userFriendlyMessage = null, HttpStatusCode? httpStatusCode = default) : base(message, inner)  {
             UserFriendlyMessage = userFriendlyMessage;
             StatusCode = httpStatusCode;
         }

--- a/src/Sepes.Infrastructure/Service/DataModelService/WbsCodeCacheModelService.cs
+++ b/src/Sepes.Infrastructure/Service/DataModelService/WbsCodeCacheModelService.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Sepes.Common.Exceptions;
+using Sepes.Infrastructure.Extensions;
 using Sepes.Infrastructure.Model;
 using Sepes.Infrastructure.Model.Context;
 using Sepes.Infrastructure.Service.DataModelService.Interface;
@@ -19,33 +21,16 @@ namespace Sepes.Infrastructure.Service.DataModelService
         {
             _logger = logger;
             _sepesDbContext = sepesDbContext;
-        }
-
-        //public async Task<bool> ExistsAndValid(string wbsCode, CancellationToken cancellation = default)
-        //{
-        //    try
-        //    {
-        //        var wbsFromDbQueryable = GetItemQueryable(wbsCode).Where(w => w.Valid && w.Expires > DateTime.UtcNow);
-
-        //        return await wbsFromDbQueryable.AnyAsync(cancellation);
-
-        //    }
-        //    catch (Exception ex)
-        //    {
-        //        _logger.LogError(ex, $"WbsCode cache lookup failed for code {wbsCode}");
-        //    }
-
-        //    return false;
-        //}
+        }       
 
         public async Task<WbsCodeCache> Get(string wbsCode, CancellationToken cancellation = default)
         {
+            _logger.LogInformation($"Wbs Cache - Get: {wbsCode}");
+
             try
             {
-                var wbsFromDbQueryable = GetItemQueryable(wbsCode).Where(w => w.Expires > DateTime.UtcNow);
-
+                var wbsFromDbQueryable = GetItemQueryable(wbsCode, true).Where(w => w.Expires > DateTime.UtcNow);
                 return await wbsFromDbQueryable.SingleOrDefaultAsync(cancellation);
-
             }
             catch (Exception ex)
             {
@@ -57,24 +42,39 @@ namespace Sepes.Infrastructure.Service.DataModelService
 
         public async Task Add(string wbsCode, bool valid)
         {
-            var queryable = GetItemQueryable(wbsCode);
+            _logger.LogInformation($"Wbs Cache - Add: {wbsCode}, valid: {valid}");
 
-            if (queryable.Any())
+            try
             {
-                var existingItem = await queryable.SingleOrDefaultAsync();
-                existingItem.Valid = valid;
+                //Executed as NoTracking, because it ensures we hit the database
+                var queryable = GetItemQueryable(wbsCode, true);
 
-                if (valid)
+                if (queryable.Any())
                 {
-                    existingItem.Expires = GetNewExpires(valid);
-                }            
-            }
-            else
-            {
-                _sepesDbContext.WbsCodeCache.Add(new WbsCodeCache(wbsCode.ToLowerInvariant(), valid, GetNewExpires(valid)));
-            }
+                    _logger.LogInformation($"Wbs Cache - Add: {wbsCode}, valid: {valid}, item exists allready");
+                    //Re-running the query, but now as a trackable, because we might be updating the entry.
 
-            await _sepesDbContext.SaveChangesAsync();
+                    queryable = GetItemQueryable(wbsCode);
+                    var existingItem = await queryable.SingleOrDefaultAsync();
+                    existingItem.Valid = valid;
+
+                    if (valid)
+                    {
+                        existingItem.Expires = GetNewExpires(valid);
+                    }
+                }
+                else
+                {
+                    _logger.LogInformation($"Wbs Cache - Add: {wbsCode}, valid: {valid}, item does not exist, adding!");
+                    _sepesDbContext.WbsCodeCache.Add(new WbsCodeCache(wbsCode.ToLowerInvariant(), valid, GetNewExpires(valid)));
+                }
+
+                await _sepesDbContext.SaveChangesAsync();
+            }
+            catch (Exception ex)
+            {
+                throw new CustomUserMessageException($"Unable to add wbs cache entry {wbsCode}, valid: {valid}", ex, $"Failed to update WBS cache");
+            }           
         }
 
         public async Task Clean()
@@ -89,9 +89,11 @@ namespace Sepes.Infrastructure.Service.DataModelService
             return DateTime.UtcNow.AddMinutes(valid ? 20 : 3);
         }
 
-        IQueryable<WbsCodeCache> GetItemQueryable(string wbsCode)
+        IQueryable<WbsCodeCache> GetItemQueryable(string wbsCode, bool asNoTracking = false)
         {
-            return _sepesDbContext.WbsCodeCache.Where(w => w.WbsCode == wbsCode.ToLower());
+            return _sepesDbContext.WbsCodeCache
+                 .If(asNoTracking, x => x.AsNoTracking())
+                .Where(w => w.WbsCode == wbsCode.ToLowerInvariant());
         }      
     }
 }


### PR DESCRIPTION
There is a potential bug where the wbs cache does not check the database, but it uses the cache from dbcontext.
Adding a AsNoTracking on the check to ensure EF goes to the DB
Closes #717 