### PR TITLE
fix(worker): lifespan of health service now transient

### DIFF
--- a/src/Sepes.Functions/Startup.cs
+++ b/src/Sepes.Functions/Startup.cs
@@ -82,7 +82,7 @@ namespace Sepes.Functions
             builder.Services.AddTransient<IRequestIdService, RequestIdService>();
             builder.Services.AddSingleton<IPublicIpFromThirdPartyService, PublicIpFromThirdPartyService>();
             builder.Services.AddSingleton<IPublicIpService, PublicIpService>();
-            builder.Services.AddSingleton<IHealthService, HealthService>();
+            builder.Services.AddTransient<IHealthService, HealthService>();
 
             //Domain Model Services
             builder.Services.AddTransient<ILookupService, LookupService>();


### PR DESCRIPTION
It was set to singleton by accident, causing warning in console and logs