### PR TITLE
fix(study): increase logo sas token timeout to 61 min

### DIFF
--- a/src/Sepes.Infrastructure/Service/Study/StudyLogoReadService.cs
+++ b/src/Sepes.Infrastructure/Service/Study/StudyLogoReadService.cs
@@ -78,7 +78,7 @@ namespace Sepes.Infrastructure.Service
 
         async Task<UriBuilder> CreateFileDownloadUriBuilder(string containerName, CancellationToken cancellationToken = default)
         {
-            return await _azureStorageAccountTokenService.CreateUriBuilder(containerName, cancellationToken: cancellationToken);
+            return await _azureStorageAccountTokenService.CreateUriBuilder(containerName, expiresOnMinutes: 61, cancellationToken: cancellationToken);
         }
 
         void DecorateLogoUrlWithSAS(UriBuilder uriBuilder, IHasLogoUrl hasLogo)


### PR DESCRIPTION
Currently, the sas token for logso timed out after 10 mins. Since the study list is cached by the front end, the images stopped appering. Increased timout to 61 min to superseed the azure ad auth token for sepes