### PR TITLE
feat: send end user email as the caller id

### DIFF
--- a/src/Sepes.Common/Constants/ConfigConstants.cs
+++ b/src/Sepes.Common/Constants/ConfigConstants.cs
@@ -61,7 +61,6 @@
         public const string SERVICE_NOW_API_URL = "ServiceNowApiUrl";
         public const string SERVICE_NOW_API_SCOPE = "ServiceNowApiScope";
         public const string SERVICE_NOW_APIM_SUBSCRIPTION = "ServiceNowApimSubscriptionKey";
-        public const string SERVICE_NOW_CALLER_ID = "ServiceNowCallerId";
         public const string SERVICE_NOW_CMDB_CI = "ServiceNowCmdbCi";
 
         public const string DATASET_STORAGEACCOUNT_ROLE_ASSIGNMENT_ID = "DatasetStorageAccountRoleAssignmentId";

--- a/src/Sepes.Common/Dto/ServiceNow/ServiceNowEnquiryCreateDto.cs
+++ b/src/Sepes.Common/Dto/ServiceNow/ServiceNowEnquiryCreateDto.cs
@@ -2,6 +2,7 @@
 {
     public class ServiceNowEnquiryCreateDto
     {
+        public string CallerId { get; set; }
         public string Category { get; set; }
         public string ShortDescription { get; set; }
     }

--- a/src/Sepes.Infrastructure/Service/ServiceNow/ServiceNowApiService.cs
+++ b/src/Sepes.Infrastructure/Service/ServiceNow/ServiceNowApiService.cs
@@ -27,10 +27,9 @@ namespace Sepes.Infrastructure.Service.ServiceNow
         {
             var serviceNowApiUrl = ConfigUtil.GetConfigValueAndThrowIfEmpty(_config, ConfigConstants.SERVICE_NOW_API_URL);
             var serviceNowSubscriptionKey = ConfigUtil.GetConfigValueAndThrowIfEmpty(_config, ConfigConstants.SERVICE_NOW_APIM_SUBSCRIPTION);
-            var callerId = ConfigUtil.GetConfigValueAndThrowIfEmpty(_config, ConfigConstants.SERVICE_NOW_CALLER_ID);
             var cmdbCi = ConfigUtil.GetConfigValueAndThrowIfEmpty(_config, ConfigConstants.SERVICE_NOW_CMDB_CI);
 
-            var requestBody = new ServiceNowRequest(callerId, enquiry.Category, cmdbCi, enquiry.ShortDescription);
+            var requestBody = new ServiceNowRequest(enquiry.CallerId, enquiry.Category, cmdbCi, enquiry.ShortDescription);
             var httpContent = new StringContent(JsonSerializerUtil.Serialize(requestBody), Encoding.UTF8, "application/json");
 
             var additionalHeaders = new Dictionary<string, string> { { "Ocp-Apim-Subscription-Key", serviceNowSubscriptionKey } };

--- a/src/Sepes.RestApi/ApiEndpoints/ServiceNow/Create.cs
+++ b/src/Sepes.RestApi/ApiEndpoints/ServiceNow/Create.cs
@@ -24,9 +24,11 @@ namespace Sepes.RestApi.ApiEndpoints.ServiceNow
         }
 
         [HttpPost]
-        public override async Task<ActionResult> HandleAsync(ServiceNowEnquiryCreateDto request, CancellationToken cancellationToken = default)
-        {
-            var response = await _serviceNowApiService.CreateEnquiry(request);
+        public override async Task<ActionResult> HandleAsync(ServiceNowEnquiryCreateDto enquiry, CancellationToken cancellationToken = default)
+        {           
+            var userNameClaim = User.Claims.SingleOrDefault(c => c.Type == "preferred_username");
+            enquiry.CallerId = userNameClaim.Value;
+            var response = await _serviceNowApiService.CreateEnquiry(enquiry);
             return new JsonResult(response);
         }
     }

--- a/src/Sepes.RestApi/appsettings.json
+++ b/src/Sepes.RestApi/appsettings.json
@@ -61,6 +61,5 @@
   "ServiceNowUrl": "",
   "ServiceNowApimSubscriptionKey": "",
   "ServiceNowScope": "",
-  "ServiceNowCallerId": "",
   "ServiceNowCmdbCi": ""
 }

--- a/src/Sepes.Tests/appsettings.json
+++ b/src/Sepes.Tests/appsettings.json
@@ -17,6 +17,5 @@
   "ServiceNowApiUrl": "https://noneExistentApi.com/api/x_stasa_serv_mgnt/v1/table/incident",
   "ServiceNowApimSubscriptionKey": "somesubscriptionkey",
   "ServiceNowApiScope": "someappid/.default",
-  "ServiceNowCallerId": "somecallerid",
   "ServiceNowCmdbCi": "somecmdbci"
 }


### PR DESCRIPTION
at the moment an enquiry is created using an internal sepes user (Integration user) in ServiceNow. This change will replace the caller as the end user when an enquiry is created.

Closes #805